### PR TITLE
Fix JSON generation

### DIFF
--- a/server.py
+++ b/server.py
@@ -217,7 +217,7 @@ class Presentation():
 
     def encode(self):
         return {
-            'root_node': self.root_node.identifier,
+            'root_node': self.root_node.id,
             'width_relationships': self.width_relationships,
             'max_width': self.max_width,
             'depth_relationships': self.depth_relationships,


### PR DESCRIPTION
This fixes the following error when requesting '/graph/present/\<node\>':

    Traceback (most recent call last):
      File "/home/pedro/.local/lib/python3.4/site-packages/bottle.py", line 862, in _handle
        return route.call(**args)
      File "/home/pedro/.local/lib/python3.4/site-packages/bottle.py", line 1738, in wrapper
        json_response = dumps(rv)
      File "/usr/lib/python3.4/json/__init__.py", line 230, in dumps
        return _default_encoder.encode(obj)
      File "/usr/lib/python3.4/json/encoder.py", line 192, in encode
        chunks = self.iterencode(o, _one_shot=True)
      File "/usr/lib/python3.4/json/encoder.py", line 250, in iterencode
        return _iterencode(o, 0)
      File "/usr/lib/python3.4/json/encoder.py", line 173, in default
        raise TypeError(repr(o) + " is not JSON serializable")
    TypeError: <function Node._create_relationship.<locals>.relationship at 0x7f57649cd048> is not JSON serializable
    127.0.0.1 - - [25/Apr/2016 17:32:40] "GET /graph/present/0 HTTP/1.1" 500 756